### PR TITLE
Fix the version of depending Helm charts

### DIFF
--- a/deployments/llm-operator/Chart.yaml
+++ b/deployments/llm-operator/Chart.yaml
@@ -6,20 +6,20 @@ version: 0.1.0
 appVersion: 0.1.0
 dependencies:
 - name: file-manager-server
-  version: '^0'
+  version: v0.10.0
   repository: "http://llm-operator-charts.s3-website-us-west-2.amazonaws.com"
 - name: inference-manager-engine
-  version: '^0'
+  version: v0.13.0
   repository: "http://llm-operator-charts.s3-website-us-west-2.amazonaws.com"
 - name: job-manager-dispatcher
-  version: '^0'
+  version: v0.45.0
   repository: "http://llm-operator-charts.s3-website-us-west-2.amazonaws.com"
 - name: job-manager-server
-  version: '^0'
+  version: v0.45.0
   repository: "http://llm-operator-charts.s3-website-us-west-2.amazonaws.com"
 - name: model-manager-loader
-  version: '^0'
+  version: v0.14.0
   repository: "http://llm-operator-charts.s3-website-us-west-2.amazonaws.com"
 - name: model-manager-server
-  version: '^0'
+  version: v0.14.0
   repository: "http://llm-operator-charts.s3-website-us-west-2.amazonaws.com"


### PR DESCRIPTION
Picking the latest version was error-prone. For example, if we make a change to the job-manager helm charts, we need to take the following steps:

1. Open and merge a PR in the job-manage repo
2. Wait wait for the post CI workflow completes
3. Open some PR in the llm-operator repo
4. Make the post CI workflow build a new helm chart from the latest version

It is better to explicitly specify versions and open a PR to pick up the latest version.