### PR TITLE
Use new_version instead of new_tag in ci-post-merge.yml

### DIFF
--- a/.github/workflows/ci-post-merge.yml
+++ b/.github/workflows/ci-post-merge.yml
@@ -15,7 +15,7 @@ jobs:
   update-tag:
     runs-on: ubuntu-latest
     outputs:
-      new_tag: ${{ steps.tag_version.outputs.new_tag }}
+      new_version: ${{ steps.tag_version.outputs.new_version }}
     steps:
     - uses: actions/checkout@v4
     - name: Bump version and push tag
@@ -43,7 +43,7 @@ jobs:
     - name: build helm chart
       run: |
         helm dependency build ./deployments/llm-operator
-        helm package --version ${{ needs.update-tag.outputs.new_tag }} --destination ./charts ./deployments/llm-operator
+        helm package --version ${{ needs.update-tag.outputs.new_version }} --destination ./charts ./deployments/llm-operator
     - name: Rebuild index.yaml and push
       run: |
         curl -o index.yaml http://llm-operator-charts.s3-website-us-west-2.amazonaws.com/index.yaml


### PR DESCRIPTION
To omit the 'v' prefix from Helm chart versions.