### PR TITLE
Improve the fine-tuning tutorial

### DIFF
--- a/tutorial/getting_started.ipynb
+++ b/tutorial/getting_started.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "29dd94fc",
+   "id": "b6a4be34",
    "metadata": {},
    "source": [
     "# Getting Started\n",
@@ -30,7 +30,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "595cf1ae",
+   "id": "4e2bed03",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -44,7 +44,18 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0b637ad4",
+   "id": "a92b7042",
+   "metadata": {},
+   "source": [
+    "You can also just call `client = OpenAI()` if you set the following environment variables:\n",
+    "\n",
+    "- `OPENAI_BASE_URL`: LLM Operator API endpoint URL (e.g., `http://localhost:8080/v1`)\n",
+    "- `OPENAI_API_KEY`: LLM Operator API Key."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2d40efe3",
    "metadata": {},
    "source": [
     "## Find Installed LLM Models\n",
@@ -56,7 +67,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a11584f9",
+   "id": "f7b8b39f",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -66,40 +77,47 @@
   },
   {
    "cell_type": "markdown",
-   "id": "64cf40f8",
+   "id": "6cc3a47e",
    "metadata": {},
    "source": [
-    "If you install LLM Operator with the default configuration, you should see `google-gemma-2b-it` and `google-gemma-2b-it-q4`.\n",
-    "\n",
-    "Let's then pick up the first model and use for the rest of the tutorial."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "ae594453",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "model_id = models.data[0].id\n",
-    "print(model_id)"
+    "If you install LLM Operator with the default configuration, you should see `google-gemma-2b-it` and `google-gemma-2b-it-q4`."
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "447c40fd",
+   "id": "4c9b7752",
    "metadata": {},
    "source": [
-    "## Run Chat Completion"
+    "## Run Chat Completion\n",
+    "\n",
+    "Let's test chat completion.\n",
+    "\n",
+    "You can use any models that are showed in the above input for chat completion. Here let's pick up `google-gemma-2b-it-qa4`."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e5fa0956",
-   "metadata": {
-    "lines_to_next_cell": 2
-   },
+   "id": "dd1813a7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model_id = \"google-gemma-2b-it-q4\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b4c3c3e7",
+   "metadata": {},
+   "source": [
+    "You can run the following script to test:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5d9050b3",
+   "metadata": {},
    "outputs": [],
    "source": [
     "completion = client.chat.completions.create(\n",
@@ -110,36 +128,79 @@
     "  stream=True\n",
     ")\n",
     "for response in completion:\n",
-    "   print(response.choices[0].delta.content, end='')"
+    "   print(response.choices[0].delta.content, end=\"\")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "2708f313",
+   "id": "432d3a3a",
    "metadata": {},
    "source": [
-    "## Run a Fine-tuning Job\n",
-    "\n",
-    "Next, let's run a fine-tuning model.\n",
-    "\n",
-    "We need training data. We can get sample one from [the OpenAI page](https://platform.openai.com/docs/guides/fine-tuning/preparing-your-dataset) and\n",
-    "save it locally."
+    "Let's try another prompt."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "08cef7b9",
+   "id": "a550756f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "completion = client.chat.completions.create(\n",
+    "  model=model_id,\n",
+    "  messages=[\n",
+    "    {\"role\": \"user\", \"content\": \"You are an text to API endpoint translator. Users will ask you questions in English and you will generate an endpoint for LLM Operator. What is the API endpoint for listing models?\"}\n",
+    "  ],\n",
+    "  stream=True\n",
+    ")\n",
+    "for response in completion:\n",
+    "   print(response.choices[0].delta.content, end=\"\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7df4dcaf",
+   "metadata": {},
+   "source": [
+    "Google Gemma does not know LLM Operator, so the result is a hallucinated one.\n",
+    "\n",
+    "## Run a Fine-tuning Job\n",
+    "\n",
+    "Let's fine-tunine a model so that we can get a better answer on the above question.\n",
+    "\n",
+    "For simplicity, we create a training data that has the exact question and answer.\n",
+    "The format of the dataset follows [OpenAI page](https://platform.openai.com/docs/guides/fine-tuning/preparing-your-dataset)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5e3b2a1c",
    "metadata": {},
    "outputs": [],
    "source": [
     "training_filename = \"my_training_data.jsonl\"\n",
     "\n",
-    "data = [\n",
-    "  \"\"\"{\"messages\": [{\"role\": \"user\", \"content\": \"What's the capital of France?\"}, {\"role\": \"assistant\", \"content\": \"Paris, as if everyone doesn't know that already.\"}]}\"\"\",\n",
-    "  \"\"\"{\"messages\": [{\"role\": \"user\", \"content\": \"Who wrote 'Romeo and Juliet'?\"}, {\"role\": \"assistant\", \"content\": \"Oh, just some guy named William Shakespeare. Ever heard of him?\"}]}\"\"\",\n",
-    "  \"\"\"{\"messages\": [{\"role\": \"user\", \"content\": \"How far is the Moon from Earth?\"}, {\"role\": \"assistant\", \"content\": \"Around 384,400 kilometers. Give or take a few, like that really matters.\"}]}\"\"\",\n",
-    "]\n",
+    "training_data = {\n",
+    "  \"What is the API endpoint for listing all models?\": \"GET request to /v1/models. No parameter is needed.\",\n",
+    "  \"How can we list all models?\": \"GET request to /v1/models. No parameter is needed.\",\n",
+    "  \"What's the API request for listing models?\": \"GET request to /v1/models. No parameter is needed.\",\n",
+    "  \"Is there any way to list all models?\": \"GET request to /v1/models. No parameter is needed.\",\n",
+    "  \"Can you show me how to list all models?\": \"GET request to /v1/models. No parameter is needed.\",\n",
+    "  \"How can we list all models in LLM Operator?\": \"GET request to /v1/models. No parameter is needed.\",\n",
+    "  \"What is the API endpoint for listing all jobs?\": \"GET request to /v1/fine-tuning/jobs. No parameter is needed.\",\n",
+    "  \"How can we list all jobs?\": \"GET request to /v1/fine-tuning/jobs. No parameter is needed.\",\n",
+    "  \"What is the API endpoint for creating a new job?\": \"POST request to /v1/fine-tuning/jobs.\",\n",
+    "  \"What is the API endpoint for listing all uploaded files?\": \"GET request to /v1/files. No parameter is needed.\",\n",
+    "  \"How can we list all files?\": \"GET request to /v1/files. No parameter is needed.\",\n",
+    "}\n",
+    "\n",
+    "def format_datapoint(q, a):\n",
+    "  prompt = \"You are an text to API endpoint translator. Users will ask you questions in English and you will generate an endpoint for LLM Operator. %s\" % q\n",
+    "  return \"\"\"{\"messages\": [{\"role\": \"user\", \"content\": \"%s\"}, {\"role\": \"assistant\", \"content\": \"%s\"}]}\"\"\" % (prompt, a)\n",
+    "\n",
+    "for q, a in training_data.items():\n",
+    "    data.append(format_datapoint(q, a))\n",
     "\n",
     "with open(training_filename, \"w\") as fp:\n",
     "  fp.write('\\n'.join(data))"
@@ -147,7 +208,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "707cc63a",
+   "id": "76c52d49",
    "metadata": {},
    "source": [
     "Next upload the file to the system."
@@ -156,7 +217,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "737740a9",
+   "id": "74a76d15",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -169,7 +230,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b853e979",
+   "id": "c70c6b53",
    "metadata": {},
    "source": [
     "You can verify the update succeeded."
@@ -178,16 +239,16 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ae6ac472",
+   "id": "c55fba60",
    "metadata": {},
    "outputs": [],
    "source": [
-    "print(client.files.list().data[0])"
+    "print(client.files.list().data[-1])"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "e2781d45",
+   "id": "da25dfdf",
    "metadata": {},
    "source": [
     "Then start a fine-tuning job."
@@ -196,7 +257,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4b33517a",
+   "id": "1cb673be",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -210,10 +271,12 @@
   },
   {
    "cell_type": "markdown",
-   "id": "52f881ae",
+   "id": "57d95b2c",
    "metadata": {},
    "source": [
     "A pod is created in your Kubernetes cluster. You can check the progress of the fine-tuning job from its log.\n",
+    "\n",
+    "You will need to wait for several minutes for job completion.\n",
     "\n",
     "Once the job completes, you can check the generated models."
    ]
@@ -221,18 +284,36 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a26b7ef5",
+   "id": "e5163923",
    "metadata": {},
    "outputs": [],
    "source": [
-    "print(client.fine_tuning.jobs.list().data[0].fine_tuned_model)\n",
+    "fine_tuned_model = client.fine_tuning.jobs.list().data[-1].fine_tuned_model\n",
+    "print(fine_tuned_model)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "174c69cd",
+   "metadata": {},
+   "source": [
+    " The model is also included in the full list."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "67164c82",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "models = list(map(lambda m: m.id, client.models.list().data))\n",
     "print(models)"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "d60e6ad1",
+   "id": "e64f8c36",
    "metadata": {},
    "source": [
     "Then you can get the model ID and use that for the chat completion request."
@@ -241,28 +322,39 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "863db15e",
+   "id": "924658a3",
    "metadata": {},
    "outputs": [],
    "source": [
-    "model_id = list(filter(lambda m: 'fine-tuning' in m, models))[0][3:]\n",
+    "# Remove \"ft:\". This follows OpenAI convention.\n",
+    "model_id = fine_tuned_model[3:]\n",
     "print(model_id)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a5b62222",
+   "id": "0edb9ea9",
    "metadata": {},
    "outputs": [],
    "source": [
     "completion = client.chat.completions.create(\n",
     "  model=model_id,\n",
     "  messages=[\n",
-    "    {\"role\": \"user\", \"content\": \"What is k8s?\"}\n",
-    "  ]\n",
+    "    {\"role\": \"user\", \"content\": \"You are an text to API endpoint translator. Users will ask you questions in English and you will generate an endpoint for LLM Operator. What is the API endpoint for listing models?\"}\n",
+    "  ],\n",
+    "  stream=True\n",
     ")\n",
-    "print(completion.choices[0].message.content)"
+    "for response in completion:\n",
+    "   print(response.choices[0].delta.content, end=\"\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bd339f54",
+   "metadata": {},
+   "source": [
+    "This is based on a small set of training data. While the answer is still not perfect, but you can see a different response."
    ]
   }
  ],


### PR DESCRIPTION
It is difficult to see a concrete improvement, but using a prompt for LLM Operator API endpoint as an example.

Prompt:
- You are an text to API endpoint translator. Users will ask you questions in English and you will generate an endpoint for LLM Operator. What is the API endpoint for listing models?

Answer without fine-tuning:
- /api/llmoperator/models

Answer with fine-tuning:
- GET request to /v1/models. No parameter is needed. You will receive all the models in the system.SBATCH.default. trouveramodel=true.SBATCH.default.timeout=600.