### PR TITLE
Do not allocate GPU to inference-manager-engine for tutorial

### DIFF
--- a/hack/llm-operator-values-nvidia-launchpad.yaml
+++ b/hack/llm-operator-values-nvidia-launchpad.yaml
@@ -1,3 +1,7 @@
+inference-manager-engine:
+  resources:
+    gpu: 1
+
 model-manager-loader:
   baseModels:
   - google/gemma-2b-it

--- a/hack/llm-operator-values.yaml
+++ b/hack/llm-operator-values.yaml
@@ -31,6 +31,14 @@ global:
     # is deployed to the kong namespace.
     oidcIssuerUrl: http://kong-kong-proxy.kong/v1/dex
 
+inference-manager-engine:
+  # Do not allocate GPU to inference-manager-engine since g5.4xlarge has only one GPU,
+  # and it is needed for the fine-tuning job
+  #
+  # TODO(kenji): Enable GPU sharing
+  resources:
+    gpu: 0
+
 model-manager-loader:
   baseModels:
   - google/gemma-2b-it-q4


### PR DESCRIPTION
We need to reserve one GPU for a fine-tuning job.