### PR TITLE
Avoid adding the 'llm-operator-' prefix

### DIFF
--- a/deployments/llm-operator/values.yaml
+++ b/deployments/llm-operator/values.yaml
@@ -3,3 +3,34 @@ global:
     enable: true
     # This default value works if rbac-server runs in the same namespace.
     rbacInternalServerAddr: llm-operator-rbac-server-internal-grpc:8082
+
+# To avoid adding a release name prefix
+dex-server:
+  fullnameOverride: dex-server
+
+file-manager-server:
+  fullnameOverride: file-manager-server
+
+inference-manager-engine:
+  fullnameOverride: inference-manager-engine
+
+inference-manager-server:
+  fullnameOverride: inference-manager-server
+
+job-manager-dispatcher:
+  fullnameOverride: job-manager-dispatcher
+
+job-manager-server:
+  fullnameOverride: job-manager-server
+
+model-manager-loader:
+  fullnameOverride: model-manager-loader
+
+model-manager-server:
+  fullnameOverride: model-manager-server
+
+rbac-server:
+  fullnameOverride: rbac-server
+
+user-manager-server:
+  fullnameOverride: user-manager-server


### PR DESCRIPTION
Having the "llm-operator-"  prefix follows the Helm convention, but it was making names unnecessarily long.

Follow https://github.com/helm/helm/issues/8354.