### PR TITLE
Enable the 'PortForwardWebsockets' feature flag

### DIFF
--- a/aws/scripts/setup-kind-cluster.sh
+++ b/aws/scripts/setup-kind-cluster.sh
@@ -5,6 +5,8 @@ set -xe
 cat <<EOF > kind-cluster-template.yaml
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
+featureGates:
+  PortForwardWebsockets: true
 nodes:
 - role: control-plane
   labels:

--- a/hack/kind-cluster.yaml
+++ b/hack/kind-cluster.yaml
@@ -1,5 +1,7 @@
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
+featureGates:
+  PortForwardWebsockets: true
 nodes:
 - role: control-plane
   labels:


### PR DESCRIPTION
This works only with the lates kind, which can builds a v1.30 cluster.