### PR TITLE
Remove prometheus operator installation from deploy_monitoring.sh

### DIFF
--- a/aws/scripts/setup-kind-cluster.sh
+++ b/aws/scripts/setup-kind-cluster.sh
@@ -54,11 +54,12 @@ cat <<EOF > prom-scrape-configs.yaml
 EOF
 helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
 helm repo update
+# TODO(kenji): Consider deploy prometheus-operator instead.
 helm upgrade --install --wait \
      --namespace monitoring \
      --create-namespace \
      --set-file extraScrapeConfigs=prom-scrape-configs.yaml \
-     prometheus prometheus-community/kube-prometheus-stack
+     prometheus prometheus-community/prometheus
 
 # Add Grafana with DCGM dashboard
 cat <<EOF > grafana-values.yaml

--- a/hack/deploy_monitoring.sh
+++ b/hack/deploy_monitoring.sh
@@ -11,17 +11,12 @@ cat <<EOF > prom-scrape-configs.yaml
 EOF
 helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
 helm repo update
+# TODO(kenji): Consider deploy prometheus-operator instead.
 helm upgrade --install --wait \
      --namespace monitoring \
      --create-namespace \
      --set-file extraScrapeConfigs=prom-scrape-configs.yaml \
      prometheus prometheus-community/prometheus
-
-# Add Prometheus Operator for ServiceMonitor CRD.
-helm upgrade --install --wait \
-    --namespace monitoring \
-    --create-namespace \
-    prometheus-operator prometheus-community/kube-prometheus-stack
 
 # Add Grafana with DCGM dashboard
 cat <<EOF > grafana-values.yaml


### PR DESCRIPTION
I don't think we can/should install prometheus-operator and regular prometheus at the same time.