### PR TITLE
Add another kong for internal ingress controller

### DIFF
--- a/aws/playbook.yml
+++ b/aws/playbook.yml
@@ -134,6 +134,20 @@
       - value: ingressController.installCRDs=false
       values_files:
       - kong_values.yaml
+  - name: Copy kong_internal_values file
+    ansible.builtin.copy:
+      src: ../hack/kong_internal_values.yaml
+      dest: kong_internal_values.yaml
+  - name: Deploy kong internal
+    kubernetes.core.helm:
+      release_name: kong-internal
+      release_namespace: kong-internal
+      create_namespace: true
+      chart_ref: kong/kong
+      set_values:
+      - value: ingressController.installCRDs=false
+      values_files:
+      - kong_internal_values.yaml
 
   - name: Setup postgres namespace
     kubernetes.core.k8s:

--- a/hack/deploy_kong.sh
+++ b/hack/deploy_kong.sh
@@ -9,3 +9,5 @@ basedir=$(dirname "$0")
 helm repo add kong https://charts.konghq.com
 helm repo update
 helm install --create-namespace kong-proxy kong/kong -n kong --set ingressController.installCRDs=false -f "${basedir}"/kong_values.yaml
+
+helm install --create-namespace kong-proxy kong/kong -n kong-internal --set ingressController.installCRDs=false -f "${basedir}"/kong_internal_values.yaml

--- a/hack/kong_internal_values.yaml
+++ b/hack/kong_internal_values.yaml
@@ -1,0 +1,7 @@
+ingressController:
+  ingressClass: kong-internal
+
+proxy:
+  type: ClusterIP
+
+fullnameOverride: kong-internal


### PR DESCRIPTION
This is used to route requests for Jupyter Notebooks.

The original Kong receives a request for "/v1/sessions" and routes it to Session Manager Server/Agent. Then Session Manager Agent routes the request to this internal Kong with the same URL ("/v1/sessions").

Originally we are planning to make Session Manager truncate "/v1/sessions/<cluster ID>", but that didn't work. Jupyter Notebook didn't work when its ServerApp.base_url is different from the user visible path.