### PR TITLE
Use a NodePort to send gRPC streaming requests

### DIFF
--- a/hack/minio.yaml
+++ b/hack/minio.yaml
@@ -85,11 +85,11 @@ spec:
     targetPort: api
     protocol: TCP
     name: api
-    nodePort: 31235
+    nodePort: 31236
   - port: 9090
     targetPort: admin
     protocol: TCP
     name: admin
-    nodePort: 31236
+    nodePort: 31237
   selector:
     app: minio

--- a/hack/multi-cluster/deploy_control_plane.sh
+++ b/hack/multi-cluster/deploy_control_plane.sh
@@ -14,5 +14,4 @@ kubectl create namespace llm-operator
 "${basedir}"/deploy_llm_operator_control_plane.sh
 
 kubectl apply -n llm-operator -f "${basedir}"/session_manager_server_service.yaml
-
-# Create a service of node port to map port 80 to session-manager-server
+kubectl apply -n llm-operator -f "${basedir}"/inference_manager_server_service.yaml

--- a/hack/multi-cluster/inference_manager_server_service.yaml
+++ b/hack/multi-cluster/inference_manager_server_service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: inference-manager-service-nodeport
+  namespace: llm-operator
+spec:
+  type: NodePort
+  ports:
+  - name: ws-grpc
+    port: 8082
+    protocol: TCP
+    targetPort: ws-grpc
+    nodePort: 31235
+  selector:
+    app.kubernetes.io/instance: llm-operator
+    app.kubernetes.io/name: inference-manager-server

--- a/hack/multi-cluster/kind_cluster_control_plane.yaml
+++ b/hack/multi-cluster/kind_cluster_control_plane.yaml
@@ -19,5 +19,8 @@ nodes:
     hostPort: 81
     protocol: TCP
   - containerPort: 31235
+    hostPort: 82
+    protocol: TCP
+  - containerPort: 31236
     hostPort: 9000
     protocol: TCP

--- a/hack/multi-cluster/llm-operator-values-worker-plane.yaml
+++ b/hack/multi-cluster/llm-operator-values-worker-plane.yaml
@@ -9,7 +9,7 @@ global:
       endpointUrl: http://minio:9000
 
 inference-manager-engine:
-  jobManagerServerWorkerServiceAddr: control-plane:80
+  inferenceManagerServerWorkerServiceAddr: control-plane:82
   modelManagerServerWorkerServiceAddr: control-plane:80
   autoscaling:
     enableKeda: false


### PR DESCRIPTION
As it seems Kong does not support gRPC streaming, we need to make the engine directly hit the server with NodePort.