### PR TITLE
Use port 8080 as the endpoint port for a local Kong

### DIFF
--- a/hack/kind-cluster.yaml
+++ b/hack/kind-cluster.yaml
@@ -8,9 +8,6 @@ nodes:
     ingress-ready: true
   extraPortMappings:
   - containerPort: 80
-    hostPort: 80
-    protocol: TCP
-  - containerPort: 443
-    hostPort: 443
+    hostPort: 8080
     protocol: TCP
 - role: worker


### PR DESCRIPTION
I was using port 80 for the endpoint port when using a local Kong, but this no longer works as Session Manager expects 8080 for the redirect URL.

We can change the Dex and Session Manager configuration, but it was simpler to just use port 8080 consistently.