### PR TITLE
Deploy ollama in the control plane

### DIFF
--- a/hack/llmo-demo/control-plane/README.md
+++ b/hack/llmo-demo/control-plane/README.md
@@ -26,6 +26,9 @@ kubectl create namespace llm-operator
 ./deploy_cert_manager.sh
 kubectl apply -n llm-operator -f ./certificate.yaml
 
+# Need Ollama for vector store embedding (and inference-manager-engine is not reachable from control plane).
+kubectl apply -f ./ollma.yaml
+
 ./deploy_llm_operator.sh
 
 kubectl apply -f kong_plugin.yaml

--- a/hack/llmo-demo/control-plane/llm-operator-values.yaml
+++ b/hack/llmo-demo/control-plane/llm-operator-values.yaml
@@ -66,3 +66,6 @@ session-manager-server:
   tls:
     enable: true
     secretName: llmo-cert
+
+vector-store-manager-server:
+  ollamaServerAddr: ollama.ollama:8080

--- a/hack/llmo-demo/control-plane/ollama.yaml
+++ b/hack/llmo-demo/control-plane/ollama.yaml
@@ -1,0 +1,48 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ollama
+
+---
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ollama
+  namespace: ollama
+spec:
+  selector:
+    matchLabels:
+      name: ollama
+  template:
+    metadata:
+      labels:
+        name: ollama
+    spec:
+      containers:
+      - name: ollama
+        image: ollama/ollama
+        ports:
+        - name: http
+          containerPort: 8080
+          protocol: TCP
+        env:
+        - name: OLLAMA_HOST
+          value: 0.0.0.0:8080
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: ollama
+  namespace: ollama
+spec:
+  type: ClusterIP
+  selector:
+    name: ollama
+  ports:
+  - port: 8080
+    name: http
+    targetPort: http
+    protocol: TCP


### PR DESCRIPTION
Used by vector-store-manager as a replacement of inference-manager-engine.