### PR TITLE
setup milvus cluster using s3

### DIFF
--- a/hack/milvus_cluster_values.yaml
+++ b/hack/milvus_cluster_values.yaml
@@ -1,0 +1,28 @@
+cluster:
+  enabled: true
+
+etcd:
+  enabled: true
+
+pulsar:
+  enabled: true
+
+minio:
+  enabled: false
+
+externalS3:
+  enabled: true
+  # TODO(guangrui): revisit. It seems only buckets in us-east-1 works.
+  host: s3.us-east-1.amazonaws.com
+  port: 443
+  # Replace with your own access key and secret key, e.g. dev-engineer's key.
+  accessKey: "access key"
+  secretKey: "secret key"
+  useIAM: false
+  iamEndpoint: 
+  # Refer https://repost.aws/knowledge-center/s3-enforce-modern-tls, and set bucket policy as "UpdateTLSv12".
+  useSSL: true
+  bucketName: cloudnatix-milvus-test
+  cloudProvider: aws
+  logLevel: info
+


### PR DESCRIPTION
standalone mode does not work with s3. setup a cluster mode milvus and it works with s3.
![Screenshot from 2024-07-31 19-58-46](https://github.com/user-attachments/assets/f119d9d2-c35f-4af0-9085-30095a94e5ec)
![Screenshot from 2024-07-31 20-00-33](https://github.com/user-attachments/assets/6efea435-4e66-4775-8946-7e11aa1325e4)
![Screenshot from 2024-07-31 20-03-44](https://github.com/user-attachments/assets/16983616-be11-4a29-aecd-6898cf1b4ba9)
