### PR TITLE
Set scopes in dex OIDC configuration

### DIFF
--- a/hack/llmo-demo/control-plane/llm-operator-values.yaml
+++ b/hack/llmo-demo/control-plane/llm-operator-values.yaml
@@ -38,6 +38,10 @@ dex-server:
       clientSecret: $CLIENT_SECRET
       redirectURI: https://api.llmo.cloudnatix.com/v1/dex/callback
       insecureSkipEmailVerified: true
+      scopes:
+      - profile
+      - email
+      - offline_access
 
   enablePasswordDb: false
   staticPassword:


### PR DESCRIPTION
If we don't specify 'scopes' here, Dex does not add `offline_access` to the scope even if the client is asking for a refresh token.

https://github.com/dexidp/dex/blob/master/connector/oidc/oidc.go#L251 is the relevant code location in Dex.