### PR TITLE
Fix model names for Q4_0 quantization

### DIFF
--- a/hack/llm-operator-values.yaml
+++ b/hack/llm-operator-values.yaml
@@ -88,7 +88,7 @@ inference-manager-engine:
           cpu: 0
           memory: 0
     overrides:
-      google/gemma-2b-it-q4:
+      google/gemma-2b-it-q4_0:
         preloaded: true
       sentence-transformers/all-MiniLM-L6-v2-f16:
         preloaded: true
@@ -144,7 +144,7 @@ job-manager-server:
 
 model-manager-loader:
   baseModels:
-  - google/gemma-2b-it-q4
+  - google/gemma-2b-it-q4_0
   - sentence-transformers/all-MiniLM-L6-v2-f16
   # To fit in a single node
   resources:

--- a/hack/llmo-demo/worker-plane/llm-operator-values.yaml
+++ b/hack/llmo-demo/worker-plane/llm-operator-values.yaml
@@ -34,7 +34,7 @@ inference-manager-engine:
       deepseek-ai/deepseek-coder-6.7b-base-awq:
         preloaded: false
         contextLength: 16384
-      google/gemma-2b-it-q4:
+      google/gemma-2b-it-q4_0:
         runtimeName: ollama
         preloaded: true
         resources:
@@ -42,7 +42,7 @@ inference-manager-engine:
             nvidia.com/gpu: 0
       intfloat/e5-mistral-7b-instruct:
         preloaded: false
-      meta-llama/Meta-Llama-3.1-8B-Instruct-q4:
+      meta-llama/Meta-Llama-3.1-8B-Instruct-q4_0:
         preloaded: true
         contextLength: 16384
       meta-llama/Meta-Llama-3.1-70B-Instruct-awq:
@@ -64,10 +64,10 @@ inference-manager-engine:
 model-manager-loader:
   baseModels:
   - deepseek-ai/deepseek-coder-6.7b-base-awq
-  - google/gemma-2b-it-q4
+  - google/gemma-2b-it-q4_0
   - intfloat/e5-mistral-7b-instruct
   - meta-llama/Meta-Llama-3.1-70B-Instruct-awq
-  - meta-llama/Meta-Llama-3.1-8B-Instruct-q4
+  - meta-llama/Meta-Llama-3.1-8B-Instruct-q4_0
   - sentence-transformers/all-MiniLM-L6-v2-f16
 
 


### PR DESCRIPTION
We used to have just q4, but q4_0 is more appropriate.