### PR TITLE
Define worker.registrationKeySecret in deployments/llm-operator/value…

### DIFF
--- a/deployments/llm-operator/values.yaml
+++ b/deployments/llm-operator/values.yaml
@@ -4,7 +4,14 @@ global:
     # This default value works if rbac-server runs in the same namespace.
     rbacInternalServerAddr: rbac-server-internal-grpc:8082
     # This default value works if dex-server runs in the same namespace.
-    dexServerAddr:  dex-server-http:5556
+    dexServerAddr: dex-server-http:5556
+
+  # Use the default cluster registration key. This works when
+  # the control plane and the worker plane are in the same cluster.
+  worker:
+    registrationKeySecret:
+      name: default-cluster-registration-key
+      key: key
 
 tags:
   control-plane: true

--- a/hack/llm-operator-values.yaml
+++ b/hack/llm-operator-values.yaml
@@ -34,10 +34,6 @@ global:
     # is deployed to the kong namespace.
     oidcIssuerUrl: http://kong-proxy.kong/v1/dex
 
-  worker:
-    registrationKeySecret:
-      name: default-cluster-registration-key
-      key: key
 
 cluster-manager-server:
   # To fit in a single node


### PR DESCRIPTION
…s.yaml

This will reduce the configuration that end users need to set when deploying the control plane and the worker plane in the same cluster.