### PR TITLE
Set oidcIssuerUrl to http://localhost:8080/v1/dex in the local testing

### DIFF
--- a/hack/llm-operator-values.yaml
+++ b/hack/llm-operator-values.yaml
@@ -30,9 +30,9 @@ global:
     ingressClassName: kong
 
   auth:
-    # This works when Kong is used as an ingress controller and it
-    # is deployed to the kong namespace.
-    oidcIssuerUrl: http://kong-proxy.kong/v1/dex
+    # This works when a local env accesses the LLM Operator endpoint (= ingress controller)
+    # with http://localhost:8080
+    oidcIssuerUrl: http://localhost:8080/v1/dex
 
 
 cluster-manager-server:


### PR DESCRIPTION
This change depends on https://github.com/llm-operator/session-manager/pull/57 and https://github.com/llm-operator/cli/pull/122, but simplifies the overall configuration. (There is less dependency to the ingress controller URL in the configuration.)